### PR TITLE
Use __DATE__ and defined build version string

### DIFF
--- a/Core/Src/nyan_strings.c
+++ b/Core/Src/nyan_strings.c
@@ -2,8 +2,10 @@
 
 #include <nyan_strings.h>
 
+#define NOS_VERSION "0.01"
+
 const uint8_t nyan_keys_welcome_text[] =
-"Nyan Keys Operating System (NOS) V0.01\r\n"
+"Nyan Keys Operating System (NOS) V" NOS_VERSION "\r\n"
 "Made by Portland.HODL\r\n"
 "\r\n";
 
@@ -21,9 +23,9 @@ const uint8_t nyan_keys_help[] =
 
 // COMMAND: getinfo
 const uint8_t nyan_keys_getinfo[] =
-"Version: 0.01\r\n"
+"Version: " NOS_VERSION "\r\n"
 "Author: Portland.HODL\r\n"
-"Built: 07/11/23\r\n";
+"Built: "__DATE__ "\r\n";
 
 const uint8_t nyan_keys_getinfo_owner[] = "Owner: "; // Make sure to newline after this is filled out from the EEPROM
 


### PR DESCRIPTION
Use todays date from the compiler.
Store version in one place.

$ arm-none-eabi-objdump --disassemble=nyan_keys_getinfo -j .rodata build/nyan_keys.elf

build/nyan_keys.elf:     file format elf32-littlearm

Disassembly of section .rodata:

080104ac <nyan_keys_getinfo>:
 80104ac:       56 65 72 73 69 6f 6e 3a 20 30 2e 30 31 0d 0a 41     Version: 0.01..A
 80104bc:       75 74 68 6f 72 3a 20 50 6f 72 74 6c 61 6e 64 2e     uthor: Portland.
 80104cc:       48 4f 44 4c 0d 0a 42 75 69 6c 74 3a 20 44 65 63     HODL..Built: Dec
 80104dc:       20 32 31 20 32 30 32 33 0d 0a 00 00                  21 2023....